### PR TITLE
added browserify dependency and start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
 	"version" : "0.2.1",
 	"dependencies" : {
 		"express" : "x",
-        "dnode" : "x",
-        "domready" : "x",
-        "dom-opts" : "git://github.com/eightyfour/dom-opts.git",
-        "canny" : "git://github.com/eightyfour/canny.git",
-        "shoe" : "x",
-        "brace" : "x"
-	}
+                "dnode" : "x",
+                "domready" : "x",
+                "dom-opts" : "git://github.com/eightyfour/dom-opts.git",
+                "canny" : "git://github.com/eightyfour/canny.git",
+                "shoe" : "x",
+                "brace" : "x",
+                "browserify" : "x"
+	},
+        "scripts" : {
+                "prestart" : "browserify resources/script/base.js lib/client/canny.js -o fe/js/min/fe.js",
+                "start" : "node app.js"
+        }
 }


### PR DESCRIPTION
browserify is now delivered by npm. there is no longer a need to manually install browserify, since npm start script is able to access the local browserify installation.
